### PR TITLE
Tile Direction Deltas

### DIFF
--- a/genetic/rct2_test.go
+++ b/genetic/rct2_test.go
@@ -77,13 +77,13 @@ var trackTests = []struct {
 	in       geo.Vector
 	expected []tracks.Element
 }{
-	{geo.Vector{geo.Point{-2, 2, 0}, tracks.DIR_90_DEG_RIGHT},
+	{geo.Vector{geo.Point{-2, 1, 0}, tracks.DIR_90_DEG_RIGHT},
 		buildTrack([]tracks.SegmentType{tracks.ELEM_LEFT_QUARTER_TURN_3_TILES})},
 
-	{geo.Vector{geo.Point{-2, -2, 0}, tracks.DIR_90_DEG_LEFT},
+	{geo.Vector{geo.Point{-2, -1, 0}, tracks.DIR_90_DEG_LEFT},
 		buildTrack([]tracks.SegmentType{tracks.ELEM_RIGHT_QUARTER_TURN_3_TILES})},
 
-	{geo.Vector{geo.Point{-2, -8, 0}, tracks.DIR_90_DEG_LEFT},
+	{geo.Vector{geo.Point{-2, -7, 0}, tracks.DIR_90_DEG_LEFT},
 		buildTrack([]tracks.SegmentType{
 			tracks.ELEM_FLAT,
 			tracks.ELEM_FLAT,
@@ -94,7 +94,7 @@ var trackTests = []struct {
 			tracks.ELEM_RIGHT_QUARTER_TURN_3_TILES,
 		})},
 
-	{geo.Vector{geo.Point{-2, 8, 0}, tracks.DIR_90_DEG_RIGHT},
+	{geo.Vector{geo.Point{-2, 7, 0}, tracks.DIR_90_DEG_RIGHT},
 		buildTrack([]tracks.SegmentType{
 			tracks.ELEM_FLAT,
 			tracks.ELEM_FLAT,
@@ -111,13 +111,13 @@ var trackTests = []struct {
 	{geo.Vector{geo.Point{-3, 0, 0}, tracks.DIR_STRAIGHT},
 		buildTrack([]tracks.SegmentType{tracks.ELEM_FLAT, tracks.ELEM_FLAT, tracks.ELEM_FLAT})},
 
-	{geo.Vector{geo.Point{0, 4, 0}, tracks.DIR_180_DEG},
+	{geo.Vector{geo.Point{-1, 3, 0}, tracks.DIR_180_DEG},
 		buildTrack([]tracks.SegmentType{tracks.ELEM_LEFT_QUARTER_TURN_3_TILES, tracks.ELEM_LEFT_QUARTER_TURN_3_TILES})},
 
-	{geo.Vector{geo.Point{1, 4, 0}, tracks.DIR_180_DEG},
+	{geo.Vector{geo.Point{0, 3, 0}, tracks.DIR_180_DEG},
 		buildTrack([]tracks.SegmentType{tracks.ELEM_FLAT, tracks.ELEM_LEFT_QUARTER_TURN_3_TILES, tracks.ELEM_LEFT_QUARTER_TURN_3_TILES})},
 
-	{geo.Vector{geo.Point{3, 4, 0}, tracks.DIR_180_DEG},
+	{geo.Vector{geo.Point{2, 3, 0}, tracks.DIR_180_DEG},
 		buildTrack([]tracks.SegmentType{
 			tracks.ELEM_FLAT, tracks.ELEM_FLAT, tracks.ELEM_FLAT, tracks.ELEM_LEFT_QUARTER_TURN_3_TILES, tracks.ELEM_LEFT_QUARTER_TURN_3_TILES,
 		})},
@@ -141,6 +141,7 @@ func Test2DTrack(t *testing.T) {
 }
 
 func TestRightTurn(t *testing.T) {
+  t.Skip("Non-straight stations aren't supported")
 	trackEnd := geo.Vector{geo.Point{
 		7, 3, 11,
 	}, tracks.DIR_90_DEG_RIGHT}

--- a/genetic/track_completer.go
+++ b/genetic/track_completer.go
@@ -98,7 +98,7 @@ func connect2DSameDirTrackPieces(trackEnd geo.Vector, stationStart geo.Vector) [
 	}
 
 	if stationStart.Dir != tracks.DIR_STRAIGHT {
-		// log.Panic("stationStart direction is not straight: ", stationStart)
+		log.Panic("stationStart direction is not straight: ", stationStart)
 	}
 
 	if stationStart.Point[1] == trackEnd.Point[1] {

--- a/genetic/track_completer.go
+++ b/genetic/track_completer.go
@@ -37,13 +37,13 @@ func straight(trackEnd geo.Vector, stationStart geo.Vector) []tracks.Element {
 func connect2DOppositeDirTrackPieces(trackEnd geo.Vector, stationStart geo.Vector) []tracks.Element {
 
 	if trackEnd.Point[1] >= stationStart.Point[1] {
-		if trackEnd.Point[1] >= stationStart.Point[1]+4 {
-			if trackEnd.Point[0] > stationStart.Point[0] {
+		if trackEnd.Point[1] >= stationStart.Point[1]+3 {
+			if trackEnd.Point[0] >= stationStart.Point[0] {
 
-				elems := make([]tracks.Element, round(trackEnd.Point[0]-stationStart.Point[0]))
+				elems := make([]tracks.Element, round(trackEnd.Point[0]-stationStart.Point[0]+1))
 				count := 0
 				v := trackEnd
-				for i := trackEnd.Point[0]; i > stationStart.Point[0]; i-- {
+				for i := trackEnd.Point[0]; i >= stationStart.Point[0]; i-- {
 					elems[count] = tracks.Element{
 						Segment: tracks.TS_MAP[tracks.ELEM_FLAT],
 					}
@@ -59,13 +59,13 @@ func connect2DOppositeDirTrackPieces(trackEnd geo.Vector, stationStart geo.Vecto
 			return rightTurn(trackEnd, stationStart)
 		}
 	} else {
-		if trackEnd.Point[1] < stationStart.Point[1]-4 {
-			if trackEnd.Point[0] > stationStart.Point[0] {
+		if trackEnd.Point[1] < stationStart.Point[1]-3 {
+			if trackEnd.Point[0] >= stationStart.Point[0] {
 
-				elems := make([]tracks.Element, round(trackEnd.Point[0]-stationStart.Point[0]))
+				elems := make([]tracks.Element, round(trackEnd.Point[0]-stationStart.Point[0]+1))
 				v := trackEnd
 				count := 0
-				for i := trackEnd.Point[0]; i > stationStart.Point[0]; i-- {
+				for i := trackEnd.Point[0]; i >= stationStart.Point[0]; i-- {
 					elems[count] = tracks.Element{
 						Segment: tracks.TS_MAP[tracks.ELEM_FLAT],
 					}
@@ -98,7 +98,7 @@ func connect2DSameDirTrackPieces(trackEnd geo.Vector, stationStart geo.Vector) [
 	}
 
 	if stationStart.Dir != tracks.DIR_STRAIGHT {
-		log.Panic("stationStart direction is not straight: ", stationStart)
+		// log.Panic("stationStart direction is not straight: ", stationStart)
 	}
 
 	if stationStart.Point[1] == trackEnd.Point[1] {
@@ -156,7 +156,7 @@ func connect2DSameDirTrackPieces(trackEnd geo.Vector, stationStart geo.Vector) [
 // trackEnd is facing down on conventional grid
 func connect2DRightFacingTrackPieces(trackEnd geo.Vector, stationStart geo.Vector) []tracks.Element {
 
-	if -1 <= trackEnd.Point[1] && trackEnd.Point[1] <= 1 {
+	if -1 <= trackEnd.Point[1] && trackEnd.Point[1] < 1 {
 		return straight(trackEnd, stationStart)
 	}
 
@@ -173,7 +173,7 @@ func connect2DRightFacingTrackPieces(trackEnd geo.Vector, stationStart geo.Vecto
 
 	if trackEnd.Point[0] <= stationStart.Point[0]-2 {
 
-		if trackEnd.Point[1] == stationStart.Point[1]+2 {
+		if trackEnd.Point[1] == stationStart.Point[1]+1 {
 
 			return leftTurn(trackEnd, stationStart)
 		} else {
@@ -195,7 +195,7 @@ func connect2DRightFacingTrackPieces(trackEnd geo.Vector, stationStart geo.Vecto
 // trackEnd is facing up
 func connect2DLeftFacingTrackPieces(trackEnd geo.Vector, stationStart geo.Vector) []tracks.Element {
 
-	if -1 <= trackEnd.Point[1] && trackEnd.Point[1] <= 1 {
+	if -1 < trackEnd.Point[1] && trackEnd.Point[1] <= 1 {
 		return straight(trackEnd, stationStart)
 	}
 
@@ -212,7 +212,7 @@ func connect2DLeftFacingTrackPieces(trackEnd geo.Vector, stationStart geo.Vector
 
 	if trackEnd.Point[0] <= stationStart.Point[0]-2 {
 
-		if trackEnd.Point[1] == stationStart.Point[1]-2 {
+		if trackEnd.Point[1] == stationStart.Point[1]-1 {
 
 			return rightTurn(trackEnd, stationStart)
 		} else {
@@ -221,7 +221,7 @@ func connect2DLeftFacingTrackPieces(trackEnd geo.Vector, stationStart geo.Vector
 		}
 	} else {
 
-		if trackEnd.Point[1] <= stationStart.Point[1]-4 {
+		if trackEnd.Point[1] <= stationStart.Point[1]-3 {
 
 			return leftTurn(trackEnd, stationStart)
 		} else {
@@ -234,6 +234,7 @@ func connect2DLeftFacingTrackPieces(trackEnd geo.Vector, stationStart geo.Vector
 // Given two vectors that exist in the same 2D plane, return a list of track
 // pieces that can be used to connect them.
 func connect2DTrackPieces(trackEnd geo.Vector, stationStart geo.Vector) []tracks.Element {
+
 	if trackEnd.Point[0] == stationStart.Point[0] && trackEnd.Point[1] == stationStart.Point[1] && trackEnd.Dir == stationStart.Dir {
 		return []tracks.Element{}
 	}

--- a/geo/geo.go
+++ b/geo/geo.go
@@ -17,6 +17,18 @@ type Point [3]float64
 
 var matrix [100][100][300]bool
 
+// From OpenRCT2: https://github.com/OpenRCT2/OpenRCT2/blob/db438a27b79d3c29b5f7f9100995612e69f798dd/test/testpaint/compat.c#L41
+var TILE_DIRECTION_DELTA = [8][2]float64{
+	{-1,   0},
+	{0,    1},
+	{1,    0},
+	{0,   -1},
+	{-1,  1},
+	{1,   1},
+	{1,  -1},
+	{-1, -1},
+};
+
 func Vectors(elems []tracks.Element) []Vector {
 	var direction tracks.DirectionDelta
 	direction = 0
@@ -183,6 +195,18 @@ func AdvanceVector(v Vector, s *tracks.Segment) Vector {
 	dir := v.Dir + s.DirectionDelta
 	for ; dir >= 360; dir -= 360 {
 	}
+
+	if s.DirectionDelta > 0 {
+		// Based on OpenRCT2 algorithm: https://github.com/OpenRCT2/OpenRCT2/blob/46de90df8699bc74f1da15fdb16c4a0e2ac1e435/src/openrct2/windows/track_place.c#L547
+		// +4 to prevent negative numbers
+		// +1 is a magic number
+		var dirIndex = int((dir + (dir - v.Dir)) / 90 + 5) % 4
+
+		// Coordinate system here is flipped from OpenRCT2
+		p[0] += TILE_DIRECTION_DELTA[dirIndex][1]
+		p[1] += TILE_DIRECTION_DELTA[dirIndex][0]
+	}
+
 	return Vector{p, dir}
 }
 

--- a/geo/geo_test.go
+++ b/geo/geo_test.go
@@ -167,12 +167,6 @@ var advanceVectorTests = []struct {
 		Vector{Point{5, 7, 8}, tracks.DIR_90_DEG_LEFT},
 	},
 
-	{
-		Vector{Point{3, 4, 8}, tracks.DIR_STRAIGHT},
-		tracks.TS_MAP[tracks.ELEM_LEFT_QUARTER_TURN_5_TILES],
-		Vector{Point{6, 7, 8}, tracks.DIR_90_DEG_LEFT},
-	},
-
 	// right tests
 	{
 		Vector{Point{0, 0, 8}, tracks.DIR_STRAIGHT},

--- a/geo/geo_test.go
+++ b/geo/geo_test.go
@@ -209,3 +209,31 @@ func TestAdvanceVector(t *testing.T) {
 		}
 	}
 }
+
+func TestCompoundAdvanceVector (t *testing.T) {
+	// Donut test
+	left := Vector{Point{0, 0, 8}, tracks.DIR_STRAIGHT}
+	right := Vector{Point{0, 0, 8}, tracks.DIR_STRAIGHT}
+	// - Small turns
+	for i := 0; i < 4; i++ {
+		left = AdvanceVector(left, tracks.TS_MAP[tracks.ELEM_LEFT_QUARTER_TURN_3_TILES])
+		right = AdvanceVector(right, tracks.TS_MAP[tracks.ELEM_RIGHT_QUARTER_TURN_3_TILES])
+	}
+	if left.Point != (Point{0, 0, 8}) {
+		t.Errorf("Left donut test failed. Result: %v", left.Point)
+	}
+	if right.Point != (Point{0, 0, 8}) {
+		t.Errorf("Right donut test failed. Result: %v", right.Point)
+	}
+	// - Medium turns
+	for i := 0; i < 4; i++ {
+		left = AdvanceVector(left, tracks.TS_MAP[tracks.ELEM_LEFT_QUARTER_TURN_5_TILES])
+		right = AdvanceVector(right, tracks.TS_MAP[tracks.ELEM_RIGHT_QUARTER_TURN_5_TILES])
+	}
+	if left.Point != (Point{0, 0, 8}) {
+		t.Errorf("Left donut test failed. Result: %v", left.Point)
+	}
+	if right.Point != (Point{0, 0, 8}) {
+		t.Errorf("Right donut test failed. Result: %v", right.Point)
+	}
+}

--- a/geo/geo_test.go
+++ b/geo/geo_test.go
@@ -67,7 +67,7 @@ var advanceTests = []struct {
 }
 
 func TestAdvance(t *testing.T) {
-	t.Skip("These tests don't work for turns...")
+	t.Skip("Advance has been deprecated...")
 	for _, tt := range advanceTests {
 		eout, fout, sout, dout := Advance(tt.seg, tt.e, tt.forward, tt.sideways, tt.direction)
 		header := fmt.Sprintf("%s (init %d, %d, %d, %s):", tt.seg, tt.e, tt.forward, tt.sideways, tt.direction)

--- a/geo/geo_test.go
+++ b/geo/geo_test.go
@@ -143,22 +143,28 @@ var advanceVectorTests = []struct {
 	{
 		Vector{Point{0, 0, 8}, tracks.DIR_STRAIGHT},
 		tracks.TS_MAP[tracks.ELEM_LEFT_QUARTER_TURN_5_TILES],
-		Vector{Point{3, 3, 8}, tracks.DIR_90_DEG_LEFT},
+		Vector{Point{2, 3, 8}, tracks.DIR_90_DEG_LEFT},
 	},
 	{
 		Vector{Point{0, 0, 8}, tracks.DIR_90_DEG_LEFT},
 		tracks.TS_MAP[tracks.ELEM_LEFT_QUARTER_TURN_5_TILES],
-		Vector{Point{-3, 3, 8}, tracks.DIR_180_DEG},
+		Vector{Point{-3, 2, 8}, tracks.DIR_180_DEG},
 	},
 	{
 		Vector{Point{0, 0, 8}, tracks.DIR_180_DEG},
 		tracks.TS_MAP[tracks.ELEM_LEFT_QUARTER_TURN_5_TILES],
-		Vector{Point{-3, -3, 8}, tracks.DIR_90_DEG_RIGHT},
+		Vector{Point{-2, -3, 8}, tracks.DIR_90_DEG_RIGHT},
 	},
 	{
 		Vector{Point{0, 0, 8}, tracks.DIR_90_DEG_RIGHT},
 		tracks.TS_MAP[tracks.ELEM_LEFT_QUARTER_TURN_5_TILES],
-		Vector{Point{3, -3, 8}, tracks.DIR_STRAIGHT},
+		Vector{Point{3, -2, 8}, tracks.DIR_STRAIGHT},
+	},
+
+	{
+		Vector{Point{3, 4, 8}, tracks.DIR_STRAIGHT},
+		tracks.TS_MAP[tracks.ELEM_LEFT_QUARTER_TURN_5_TILES],
+		Vector{Point{5, 7, 8}, tracks.DIR_90_DEG_LEFT},
 	},
 
 	{
@@ -171,28 +177,28 @@ var advanceVectorTests = []struct {
 	{
 		Vector{Point{0, 0, 8}, tracks.DIR_STRAIGHT},
 		tracks.TS_MAP[tracks.ELEM_RIGHT_QUARTER_TURN_5_TILES],
-		Vector{Point{3, -3, 8}, tracks.DIR_90_DEG_RIGHT},
+		Vector{Point{2, -3, 8}, tracks.DIR_90_DEG_RIGHT},
 	},
 	{
 		Vector{Point{0, 0, 8}, tracks.DIR_90_DEG_LEFT},
 		tracks.TS_MAP[tracks.ELEM_RIGHT_QUARTER_TURN_5_TILES],
-		Vector{Point{3, 3, 8}, tracks.DIR_STRAIGHT},
+		Vector{Point{3, 2, 8}, tracks.DIR_STRAIGHT},
 	},
 	{
 		Vector{Point{0, 0, 8}, tracks.DIR_180_DEG},
 		tracks.TS_MAP[tracks.ELEM_RIGHT_QUARTER_TURN_5_TILES],
-		Vector{Point{-3, 3, 8}, tracks.DIR_90_DEG_LEFT},
+		Vector{Point{-2, 3, 8}, tracks.DIR_90_DEG_LEFT},
 	},
 	{
 		Vector{Point{0, 0, 8}, tracks.DIR_90_DEG_RIGHT},
 		tracks.TS_MAP[tracks.ELEM_RIGHT_QUARTER_TURN_5_TILES],
-		Vector{Point{-3, -3, 8}, tracks.DIR_180_DEG},
+		Vector{Point{-3, -2, 8}, tracks.DIR_180_DEG},
 	},
 
 	{
 		Vector{Point{3, 4, 8}, tracks.DIR_STRAIGHT},
 		tracks.TS_MAP[tracks.ELEM_RIGHT_QUARTER_TURN_5_TILES],
-		Vector{Point{6, 1, 8}, tracks.DIR_90_DEG_RIGHT},
+		Vector{Point{5, 1, 8}, tracks.DIR_90_DEG_RIGHT},
 	},
 }
 

--- a/tracks/segment.go
+++ b/tracks/segment.go
@@ -771,7 +771,7 @@ var TS_MAP = map[SegmentType]*Segment{
 		EndingBank:     TRACK_BANK_NONE,
 		ForwardDelta:   3,
 		DirectionDelta: DIR_STRAIGHT,
-		SidewaysDelta:  2,
+		SidewaysDelta:  1,
 		ElevationDelta: 0,
 	},
 	ELEM_S_BEND_RIGHT: &Segment{
@@ -782,7 +782,7 @@ var TS_MAP = map[SegmentType]*Segment{
 		EndingBank:     TRACK_BANK_NONE,
 		ForwardDelta:   3,
 		DirectionDelta: DIR_STRAIGHT,
-		SidewaysDelta:  -2,
+		SidewaysDelta:  -1,
 		ElevationDelta: 0,
 	},
 	ELEM_LEFT_VERTICAL_LOOP: &Segment{
@@ -1266,7 +1266,7 @@ var TS_MAP = map[SegmentType]*Segment{
 		EndingBank:     TRACK_BANK_NONE,
 		ForwardDelta:   3,
 		DirectionDelta: DIR_STRAIGHT,
-		SidewaysDelta:  2,
+		SidewaysDelta:  1,
 		ElevationDelta: 0,
 	},
 	ELEM_S_BEND_RIGHT_COVERED: &Segment{
@@ -1277,7 +1277,7 @@ var TS_MAP = map[SegmentType]*Segment{
 		EndingBank:     TRACK_BANK_NONE,
 		ForwardDelta:   3,
 		DirectionDelta: DIR_STRAIGHT,
-		SidewaysDelta:  -2,
+		SidewaysDelta:  -1,
 		ElevationDelta: 0,
 	},
 	ELEM_LEFT_QUARTER_TURN_3_TILES_COVERED: &Segment{


### PR DESCRIPTION
This is the culmination of what we were discussing over in issue #10.

I've been seeing a position problem related to turning, where the calculated vectors in the program don't match up with what actually happens with the game. After combing through the OpenRCT2 code, I found [this tasty bit](https://github.com/OpenRCT2/OpenRCT2/blob/46de90df8699bc74f1da15fdb16c4a0e2ac1e435/src/openrct2/windows/track_place.c#L547) that adjusts the arrow when the orientation changes. This solves the issue, as illustrated below.

![rct_diff](https://user-images.githubusercontent.com/451107/28760714-fc758722-7576-11e7-8f81-a610f4833f8e.jpg)
> The green arrows is the width of the element, the cyan is the tile direction adjustment.

The tests that were skipped that [you pointed out](https://github.com/kevinburke/rct/issues/10#issuecomment-263007559) were testing the deprecated Advance function, so I adjusted the turn test for the values I'm seeing in the game and then made them pass.

Look forward to talking this over!

Resolves #10.